### PR TITLE
OSX projects and a base frequency finder function

### DIFF
--- a/FFTAccelerate.xcodeproj/project.pbxproj
+++ b/FFTAccelerate.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		042600471CF255A900D4CE95 /* libFFTAccelerateLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 042600461CF255A900D4CE95 /* libFFTAccelerateLib.a */; };
 		E2814EC114E8169300AFCFFF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2814EC014E8169300AFCFFF /* UIKit.framework */; };
 		E2814EC314E8169300AFCFFF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2814EC214E8169300AFCFFF /* Foundation.framework */; };
 		E2814EC514E8169300AFCFFF /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2814EC414E8169300AFCFFF /* CoreGraphics.framework */; };
@@ -21,7 +22,6 @@
 		E2814EE414E8169300AFCFFF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2814EC214E8169300AFCFFF /* Foundation.framework */; };
 		E2814EEC14E8169300AFCFFF /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E2814EEA14E8169300AFCFFF /* InfoPlist.strings */; };
 		E2814EEF14E8169300AFCFFF /* FFTAccelerateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E2814EEE14E8169300AFCFFF /* FFTAccelerateTests.m */; };
-		E2814EFA14E816C800AFCFFF /* FFTAccelerate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E2814EF814E816C800AFCFFF /* FFTAccelerate.cpp */; };
 		E2814EFD14E816F200AFCFFF /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2814EFC14E816F200AFCFFF /* Accelerate.framework */; };
 /* End PBXBuildFile section */
 
@@ -36,6 +36,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		042600461CF255A900D4CE95 /* libFFTAccelerateLib.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFFTAccelerateLib.a; path = "../../Library/Developer/Xcode/DerivedData/FFTAccelerate-eiyoyppcpzjvregbjokdidrebfqo/Build/Products/Debug-iphoneos/libFFTAccelerateLib.a"; sourceTree = "<group>"; };
 		E2814EBC14E8169300AFCFFF /* FFTAccelerate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FFTAccelerate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2814EC014E8169300AFCFFF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		E2814EC214E8169300AFCFFF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -56,8 +57,6 @@
 		E2814EEB14E8169300AFCFFF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E2814EED14E8169300AFCFFF /* FFTAccelerateTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FFTAccelerateTests.h; sourceTree = "<group>"; };
 		E2814EEE14E8169300AFCFFF /* FFTAccelerateTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FFTAccelerateTests.m; sourceTree = "<group>"; };
-		E2814EF814E816C800AFCFFF /* FFTAccelerate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FFTAccelerate.cpp; sourceTree = "<group>"; };
-		E2814EF914E816C800AFCFFF /* FFTAccelerate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FFTAccelerate.h; sourceTree = "<group>"; };
 		E2814EFC14E816F200AFCFFF /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -66,6 +65,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				042600471CF255A900D4CE95 /* libFFTAccelerateLib.a in Frameworks */,
 				E2814EFD14E816F200AFCFFF /* Accelerate.framework in Frameworks */,
 				E2814EC114E8169300AFCFFF /* UIKit.framework in Frameworks */,
 				E2814EC314E8169300AFCFFF /* Foundation.framework in Frameworks */,
@@ -90,6 +90,7 @@
 			isa = PBXGroup;
 			children = (
 				E2814EFC14E816F200AFCFFF /* Accelerate.framework */,
+				042600461CF255A900D4CE95 /* libFFTAccelerateLib.a */,
 				E2814EC614E8169300AFCFFF /* FFTAccelerate */,
 				E2814EE714E8169300AFCFFF /* FFTAccelerateTests */,
 				E2814EBF14E8169300AFCFFF /* Frameworks */,
@@ -126,8 +127,6 @@
 				E2814ED314E8169300AFCFFF /* ViewController.m */,
 				E2814ED514E8169300AFCFFF /* ViewController_iPhone.xib */,
 				E2814ED814E8169300AFCFFF /* ViewController_iPad.xib */,
-				E2814EF814E816C800AFCFFF /* FFTAccelerate.cpp */,
-				E2814EF914E816C800AFCFFF /* FFTAccelerate.h */,
 				E2814EC714E8169300AFCFFF /* Supporting Files */,
 			);
 			path = FFTAccelerate;
@@ -274,7 +273,6 @@
 				E2814ECD14E8169300AFCFFF /* main.m in Sources */,
 				E2814ED114E8169300AFCFFF /* AppDelegate.mm in Sources */,
 				E2814ED414E8169300AFCFFF /* ViewController.m in Sources */,
-				E2814EFA14E816C800AFCFFF /* FFTAccelerate.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FFTAccelerate.xcodeproj/project.pbxproj
+++ b/FFTAccelerate.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		042600471CF255A900D4CE95 /* libFFTAccelerateLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 042600461CF255A900D4CE95 /* libFFTAccelerateLib.a */; };
+		04604A201CF261C100DD1FEB /* libFFTAccelerate.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 04604A1B1CF2610D00DD1FEB /* libFFTAccelerate.a */; };
 		E2814EC114E8169300AFCFFF /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2814EC014E8169300AFCFFF /* UIKit.framework */; };
 		E2814EC314E8169300AFCFFF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2814EC214E8169300AFCFFF /* Foundation.framework */; };
 		E2814EC514E8169300AFCFFF /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2814EC414E8169300AFCFFF /* CoreGraphics.framework */; };
@@ -26,6 +26,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		04604A1A1CF2610D00DD1FEB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 04604A161CF2610C00DD1FEB /* FFTAccelerateLib.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 042600291CF253C000D4CE95;
+			remoteInfo = FFTAccelerateLib;
+		};
+		04604A1E1CF2618800DD1FEB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 04604A161CF2610C00DD1FEB /* FFTAccelerateLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 042600281CF253C000D4CE95;
+			remoteInfo = FFTAccelerateLib;
+		};
 		E2814EE514E8169300AFCFFF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E2814EB314E8169300AFCFFF /* Project object */;
@@ -36,7 +50,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		042600461CF255A900D4CE95 /* libFFTAccelerateLib.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFFTAccelerateLib.a; path = "../../Library/Developer/Xcode/DerivedData/FFTAccelerate-eiyoyppcpzjvregbjokdidrebfqo/Build/Products/Debug-iphoneos/libFFTAccelerateLib.a"; sourceTree = "<group>"; };
+		04604A081CF25FF500DD1FEB /* libFFTAccelerate.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFFTAccelerate.a; path = "../../Library/Developer/Xcode/DerivedData/FFTAccelerate-eiyoyppcpzjvregbjokdidrebfqo/Build/Products/Debug-iphoneos/libFFTAccelerate.a"; sourceTree = "<group>"; };
+		04604A161CF2610C00DD1FEB /* FFTAccelerateLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = FFTAccelerateLib.xcodeproj; sourceTree = "<group>"; };
 		E2814EBC14E8169300AFCFFF /* FFTAccelerate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FFTAccelerate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2814EC014E8169300AFCFFF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		E2814EC214E8169300AFCFFF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -65,7 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				042600471CF255A900D4CE95 /* libFFTAccelerateLib.a in Frameworks */,
+				04604A201CF261C100DD1FEB /* libFFTAccelerate.a in Frameworks */,
 				E2814EFD14E816F200AFCFFF /* Accelerate.framework in Frameworks */,
 				E2814EC114E8169300AFCFFF /* UIKit.framework in Frameworks */,
 				E2814EC314E8169300AFCFFF /* Foundation.framework in Frameworks */,
@@ -86,11 +101,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		04604A171CF2610C00DD1FEB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				04604A1B1CF2610D00DD1FEB /* libFFTAccelerate.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		E2814EB114E8169300AFCFFF = {
 			isa = PBXGroup;
 			children = (
+				04604A161CF2610C00DD1FEB /* FFTAccelerateLib.xcodeproj */,
 				E2814EFC14E816F200AFCFFF /* Accelerate.framework */,
-				042600461CF255A900D4CE95 /* libFFTAccelerateLib.a */,
 				E2814EC614E8169300AFCFFF /* FFTAccelerate */,
 				E2814EE714E8169300AFCFFF /* FFTAccelerateTests */,
 				E2814EBF14E8169300AFCFFF /* Frameworks */,
@@ -110,6 +133,7 @@
 		E2814EBF14E8169300AFCFFF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				04604A081CF25FF500DD1FEB /* libFFTAccelerate.a */,
 				E2814EC014E8169300AFCFFF /* UIKit.framework */,
 				E2814EC214E8169300AFCFFF /* Foundation.framework */,
 				E2814EC414E8169300AFCFFF /* CoreGraphics.framework */,
@@ -176,6 +200,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				04604A1F1CF2618800DD1FEB /* PBXTargetDependency */,
 			);
 			name = FFTAccelerate;
 			productName = FFTAccelerate;
@@ -220,6 +245,12 @@
 			mainGroup = E2814EB114E8169300AFCFFF;
 			productRefGroup = E2814EBD14E8169300AFCFFF /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 04604A171CF2610C00DD1FEB /* Products */;
+					ProjectRef = 04604A161CF2610C00DD1FEB /* FFTAccelerateLib.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				E2814EBB14E8169300AFCFFF /* FFTAccelerate */,
@@ -227,6 +258,16 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		04604A1B1CF2610D00DD1FEB /* libFFTAccelerate.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libFFTAccelerate.a;
+			remoteRef = 04604A1A1CF2610D00DD1FEB /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		E2814EBA14E8169300AFCFFF /* Resources */ = {
@@ -287,6 +328,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		04604A1F1CF2618800DD1FEB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FFTAccelerateLib;
+			targetProxy = 04604A1E1CF2618800DD1FEB /* PBXContainerItemProxy */;
+		};
 		E2814EE614E8169300AFCFFF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E2814EBB14E8169300AFCFFF /* FFTAccelerate */;

--- a/FFTAccelerate.xcodeproj/project.pbxproj
+++ b/FFTAccelerate.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 			name = FFTAccelerateTests;
 			productName = FFTAccelerateTests;
 			productReference = E2814EE014E8169300AFCFFF /* FFTAccelerateTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -208,6 +208,7 @@
 		E2814EB314E8169300AFCFFF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastTestingUpgradeCheck = 0730;
 				LastUpgradeCheck = 0420;
 			};
 			buildConfigurationList = E2814EB614E8169300AFCFFF /* Build configuration list for PBXProject "FFTAccelerate" */;

--- a/FFTAccelerate.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/FFTAccelerate.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/FFTAccelerate.xcworkspace/contents.xcworkspacedata
+++ b/FFTAccelerate.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,10 @@
    <FileRef
       location = "group:FFTAccelerateLib.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:FFTAccelerateOSX.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:FFTAccelerateLibOSX.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/FFTAccelerate.xcworkspace/contents.xcworkspacedata
+++ b/FFTAccelerate.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:FFTAccelerate.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:FFTAccelerateLib.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/FFTAccelerate/AppDelegate.mm
+++ b/FFTAccelerate/AppDelegate.mm
@@ -68,6 +68,8 @@
     for (int i=0; i<numSamples; i++) {
         NSLog(@"index: %d, amp: %.2f",i, frequency[i]);
     }
+    NSLog(@"Fullest bin index: %d", fftAccel->fullestBin(frequency, numSamples, false));
+    NSLog(@"Fullest bin index (ignoring DC): %d", fftAccel->fullestBin(frequency, numSamples, true));
     delete(fftAccel);
     return YES;
 }

--- a/FFTAccelerate/FFTAccelerate.cpp
+++ b/FFTAccelerate/FFTAccelerate.cpp
@@ -39,6 +39,18 @@ void FFTAccelerate::doFFTReal(float samples[], float amp[], int numSamples)
     vDSP_vsdiv(amp, 1, &fNumSamples, amp, 1, numSamples);   // /numSamples
 }
 
+int FFTAccelerate::fullestBin(float samples[], int numSamples, bool ignoreDC)
+{
+    int offset = 0;
+    vDSP_Length fullestIndex;
+    float fullestValue;
+    if (ignoreDC) {
+        offset = 1;
+    }
+    vDSP_maxvi(samples+offset, 1, &fullestValue, &fullestIndex, numSamples-offset);
+    return (int)fullestIndex+offset;
+}
+
 //Constructor
 FFTAccelerate::FFTAccelerate (int numSamples)
 {

--- a/FFTAccelerate/FFTAccelerate.h
+++ b/FFTAccelerate/FFTAccelerate.h
@@ -22,6 +22,7 @@ class FFTAccelerate
 		FFTAccelerate(int numSamples);
 		~FFTAccelerate();
     void doFFTReal(float samples[], float amp[], int numSamples);
+    int fullestBin(float samples[], int numSamples, bool ignoreDC);
 
 private: 
 		FFTSetup fftSetup;

--- a/FFTAccelerateLib.xcodeproj/project.pbxproj
+++ b/FFTAccelerateLib.xcodeproj/project.pbxproj
@@ -1,0 +1,254 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		042600451CF2550100D4CE95 /* FFTAccelerate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 042600431CF2550100D4CE95 /* FFTAccelerate.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		042600271CF253C000D4CE95 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		042600291CF253C000D4CE95 /* libFFTAccelerateLib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFFTAccelerateLib.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		042600431CF2550100D4CE95 /* FFTAccelerate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FFTAccelerate.cpp; path = ../FFTAccelerate/FFTAccelerate.cpp; sourceTree = "<group>"; };
+		042600441CF2550100D4CE95 /* FFTAccelerate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FFTAccelerate.h; path = ../FFTAccelerate/FFTAccelerate.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		042600261CF253C000D4CE95 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		042600201CF253C000D4CE95 = {
+			isa = PBXGroup;
+			children = (
+				0426002B1CF253C000D4CE95 /* FFTAccelerateLib */,
+				0426002A1CF253C000D4CE95 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0426002A1CF253C000D4CE95 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				042600291CF253C000D4CE95 /* libFFTAccelerateLib.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		0426002B1CF253C000D4CE95 /* FFTAccelerateLib */ = {
+			isa = PBXGroup;
+			children = (
+				042600431CF2550100D4CE95 /* FFTAccelerate.cpp */,
+				042600441CF2550100D4CE95 /* FFTAccelerate.h */,
+			);
+			path = FFTAccelerateLib;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		042600281CF253C000D4CE95 /* FFTAccelerateLib */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 042600321CF253C000D4CE95 /* Build configuration list for PBXNativeTarget "FFTAccelerateLib" */;
+			buildPhases = (
+				042600251CF253C000D4CE95 /* Sources */,
+				042600261CF253C000D4CE95 /* Frameworks */,
+				042600271CF253C000D4CE95 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FFTAccelerateLib;
+			productName = FFTAccelerateLib;
+			productReference = 042600291CF253C000D4CE95 /* libFFTAccelerateLib.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		042600211CF253C000D4CE95 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = "Jack Jansen";
+				TargetAttributes = {
+					042600281CF253C000D4CE95 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 042600241CF253C000D4CE95 /* Build configuration list for PBXProject "FFTAccelerateLib" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 042600201CF253C000D4CE95;
+			productRefGroup = 0426002A1CF253C000D4CE95 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				042600281CF253C000D4CE95 /* FFTAccelerateLib */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		042600251CF253C000D4CE95 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				042600451CF2550100D4CE95 /* FFTAccelerate.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		042600301CF253C000D4CE95 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		042600311CF253C000D4CE95 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		042600331CF253C000D4CE95 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		042600341CF253C000D4CE95 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		042600241CF253C000D4CE95 /* Build configuration list for PBXProject "FFTAccelerateLib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				042600301CF253C000D4CE95 /* Debug */,
+				042600311CF253C000D4CE95 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		042600321CF253C000D4CE95 /* Build configuration list for PBXNativeTarget "FFTAccelerateLib" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				042600331CF253C000D4CE95 /* Debug */,
+				042600341CF253C000D4CE95 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 042600211CF253C000D4CE95 /* Project object */;
+}

--- a/FFTAccelerateLib.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/FFTAccelerateLib.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:FFTAccelerateLib.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/FFTAccelerateLibOSX.xcodeproj/project.pbxproj
+++ b/FFTAccelerateLibOSX.xcodeproj/project.pbxproj
@@ -7,29 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		042600451CF2550100D4CE95 /* FFTAccelerate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 042600431CF2550100D4CE95 /* FFTAccelerate.cpp */; };
+		0426006E1CF25AC000D4CE95 /* FFTAccelerate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0426006C1CF25AC000D4CE95 /* FFTAccelerate.cpp */; };
+		0426006F1CF25AC000D4CE95 /* FFTAccelerate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0426006D1CF25AC000D4CE95 /* FFTAccelerate.h */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		042600271CF253C000D4CE95 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
-		042600291CF253C000D4CE95 /* libFFTAccelerate.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFFTAccelerate.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		042600431CF2550100D4CE95 /* FFTAccelerate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FFTAccelerate.cpp; path = ../FFTAccelerate/FFTAccelerate.cpp; sourceTree = "<group>"; };
-		042600441CF2550100D4CE95 /* FFTAccelerate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FFTAccelerate.h; path = ../FFTAccelerate/FFTAccelerate.h; sourceTree = "<group>"; };
+		042600511CF259C900D4CE95 /* libFFTAccelerateOSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFFTAccelerateOSX.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		0426006C1CF25AC000D4CE95 /* FFTAccelerate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FFTAccelerate.cpp; path = FFTAccelerateLib/../FFTAccelerate/FFTAccelerate.cpp; sourceTree = "<group>"; };
+		0426006D1CF25AC000D4CE95 /* FFTAccelerate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FFTAccelerate.h; path = FFTAccelerateLib/../FFTAccelerate/FFTAccelerate.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		042600261CF253C000D4CE95 /* Frameworks */ = {
+		0426004E1CF259C900D4CE95 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -39,95 +28,106 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		042600201CF253C000D4CE95 = {
+		042600481CF259C900D4CE95 = {
 			isa = PBXGroup;
 			children = (
-				0426002B1CF253C000D4CE95 /* FFTAccelerateLib */,
-				0426002A1CF253C000D4CE95 /* Products */,
+				0426006B1CF25AAD00D4CE95 /* FFTAccelerateLib */,
+				042600521CF259C900D4CE95 /* Products */,
 			);
 			sourceTree = "<group>";
 		};
-		0426002A1CF253C000D4CE95 /* Products */ = {
+		042600521CF259C900D4CE95 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				042600291CF253C000D4CE95 /* libFFTAccelerate.a */,
+				042600511CF259C900D4CE95 /* libFFTAccelerateOSX.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		0426002B1CF253C000D4CE95 /* FFTAccelerateLib */ = {
+		0426006B1CF25AAD00D4CE95 /* FFTAccelerateLib */ = {
 			isa = PBXGroup;
 			children = (
-				042600431CF2550100D4CE95 /* FFTAccelerate.cpp */,
-				042600441CF2550100D4CE95 /* FFTAccelerate.h */,
+				0426006C1CF25AC000D4CE95 /* FFTAccelerate.cpp */,
+				0426006D1CF25AC000D4CE95 /* FFTAccelerate.h */,
 			);
-			path = FFTAccelerateLib;
+			name = FFTAccelerateLib;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		0426004F1CF259C900D4CE95 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0426006F1CF25AC000D4CE95 /* FFTAccelerate.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
-		042600281CF253C000D4CE95 /* FFTAccelerateLib */ = {
+		042600501CF259C900D4CE95 /* FFTAccelerateLibOSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 042600321CF253C000D4CE95 /* Build configuration list for PBXNativeTarget "FFTAccelerateLib" */;
+			buildConfigurationList = 042600551CF259C900D4CE95 /* Build configuration list for PBXNativeTarget "FFTAccelerateLibOSX" */;
 			buildPhases = (
-				042600251CF253C000D4CE95 /* Sources */,
-				042600261CF253C000D4CE95 /* Frameworks */,
-				042600271CF253C000D4CE95 /* CopyFiles */,
+				0426004D1CF259C900D4CE95 /* Sources */,
+				0426004E1CF259C900D4CE95 /* Frameworks */,
+				0426004F1CF259C900D4CE95 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = FFTAccelerateLib;
-			productName = FFTAccelerateLib;
-			productReference = 042600291CF253C000D4CE95 /* libFFTAccelerate.a */;
+			name = FFTAccelerateLibOSX;
+			productName = FFTAccelerateLibOSX;
+			productReference = 042600511CF259C900D4CE95 /* libFFTAccelerateOSX.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		042600211CF253C000D4CE95 /* Project object */ = {
+		042600491CF259C900D4CE95 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Jack Jansen";
 				TargetAttributes = {
-					042600281CF253C000D4CE95 = {
+					042600501CF259C900D4CE95 = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
 				};
 			};
-			buildConfigurationList = 042600241CF253C000D4CE95 /* Build configuration list for PBXProject "FFTAccelerateLib" */;
+			buildConfigurationList = 0426004C1CF259C900D4CE95 /* Build configuration list for PBXProject "FFTAccelerateLibOSX" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 042600201CF253C000D4CE95;
-			productRefGroup = 0426002A1CF253C000D4CE95 /* Products */;
+			mainGroup = 042600481CF259C900D4CE95;
+			productRefGroup = 042600521CF259C900D4CE95 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				042600281CF253C000D4CE95 /* FFTAccelerateLib */,
+				042600501CF259C900D4CE95 /* FFTAccelerateLibOSX */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		042600251CF253C000D4CE95 /* Sources */ = {
+		0426004D1CF259C900D4CE95 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				042600451CF2550100D4CE95 /* FFTAccelerate.cpp in Sources */,
+				0426006E1CF25AC000D4CE95 /* FFTAccelerate.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		042600301CF253C000D4CE95 /* Debug */ = {
+		042600531CF259C900D4CE95 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -145,7 +145,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -164,14 +164,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
-		042600311CF253C000D4CE95 /* Release */ = {
+		042600541CF259C900D4CE95 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -189,7 +189,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -202,53 +202,50 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
-				VALIDATE_PRODUCT = YES;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
-		042600331CF253C000D4CE95 /* Debug */ = {
+		042600561CF259C900D4CE95 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = FFTAccelerate;
-				SKIP_INSTALL = YES;
+				EXECUTABLE_PREFIX = lib;
+				PRODUCT_NAME = FFTAccelerateOSX;
 			};
 			name = Debug;
 		};
-		042600341CF253C000D4CE95 /* Release */ = {
+		042600571CF259C900D4CE95 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = FFTAccelerate;
-				SKIP_INSTALL = YES;
+				EXECUTABLE_PREFIX = lib;
+				PRODUCT_NAME = FFTAccelerateOSX;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		042600241CF253C000D4CE95 /* Build configuration list for PBXProject "FFTAccelerateLib" */ = {
+		0426004C1CF259C900D4CE95 /* Build configuration list for PBXProject "FFTAccelerateLibOSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				042600301CF253C000D4CE95 /* Debug */,
-				042600311CF253C000D4CE95 /* Release */,
+				042600531CF259C900D4CE95 /* Debug */,
+				042600541CF259C900D4CE95 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		042600321CF253C000D4CE95 /* Build configuration list for PBXNativeTarget "FFTAccelerateLib" */ = {
+		042600551CF259C900D4CE95 /* Build configuration list for PBXNativeTarget "FFTAccelerateLibOSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				042600331CF253C000D4CE95 /* Debug */,
-				042600341CF253C000D4CE95 /* Release */,
+				042600561CF259C900D4CE95 /* Debug */,
+				042600571CF259C900D4CE95 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 042600211CF253C000D4CE95 /* Project object */;
+	rootObject = 042600491CF259C900D4CE95 /* Project object */;
 }

--- a/FFTAccelerateLibOSX.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/FFTAccelerateLibOSX.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:FFTAccelerateLibOSX.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/FFTAccelerateOSX.xcodeproj/project.pbxproj
+++ b/FFTAccelerateOSX.xcodeproj/project.pbxproj
@@ -1,0 +1,319 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		042600651CF259F400D4CE95 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 042600641CF259F400D4CE95 /* main.cpp */; };
+		04604A0D1CF2603100DD1FEB /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04604A0C1CF2603100DD1FEB /* Accelerate.framework */; };
+		04604A0F1CF260C300DD1FEB /* libFFTAccelerateOSX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 04604A0E1CF260C300DD1FEB /* libFFTAccelerateOSX.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		04604A141CF260F700DD1FEB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 04604A101CF260F600DD1FEB /* FFTAccelerateLibOSX.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 042600511CF259C900D4CE95;
+			remoteInfo = FFTAccelerateLibOSX;
+		};
+		04604A1C1CF2617E00DD1FEB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 04604A101CF260F600DD1FEB /* FFTAccelerateLibOSX.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 042600501CF259C900D4CE95;
+			remoteInfo = FFTAccelerateLibOSX;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		0426005F1CF259F400D4CE95 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		042600611CF259F400D4CE95 /* FFTAccelerateOSX */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = FFTAccelerateOSX; sourceTree = BUILT_PRODUCTS_DIR; };
+		042600641CF259F400D4CE95 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+		04604A0A1CF25FFF00DD1FEB /* libFFTAccelerate.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFFTAccelerate.a; path = "../../Library/Developer/Xcode/DerivedData/FFTAccelerate-eiyoyppcpzjvregbjokdidrebfqo/Build/Products/Debug/libFFTAccelerate.a"; sourceTree = "<group>"; };
+		04604A0C1CF2603100DD1FEB /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		04604A0E1CF260C300DD1FEB /* libFFTAccelerateOSX.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libFFTAccelerateOSX.a; path = build/Debug/libFFTAccelerateOSX.a; sourceTree = "<group>"; };
+		04604A101CF260F600DD1FEB /* FFTAccelerateLibOSX.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = FFTAccelerateLibOSX.xcodeproj; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0426005E1CF259F400D4CE95 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				04604A0F1CF260C300DD1FEB /* libFFTAccelerateOSX.a in Frameworks */,
+				04604A0D1CF2603100DD1FEB /* Accelerate.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		042600581CF259F400D4CE95 = {
+			isa = PBXGroup;
+			children = (
+				04604A0E1CF260C300DD1FEB /* libFFTAccelerateOSX.a */,
+				04604A101CF260F600DD1FEB /* FFTAccelerateLibOSX.xcodeproj */,
+				04604A0C1CF2603100DD1FEB /* Accelerate.framework */,
+				04604A0A1CF25FFF00DD1FEB /* libFFTAccelerate.a */,
+				042600631CF259F400D4CE95 /* FFTAccelerateOSX */,
+				042600621CF259F400D4CE95 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		042600621CF259F400D4CE95 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				042600611CF259F400D4CE95 /* FFTAccelerateOSX */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		042600631CF259F400D4CE95 /* FFTAccelerateOSX */ = {
+			isa = PBXGroup;
+			children = (
+				042600641CF259F400D4CE95 /* main.cpp */,
+			);
+			path = FFTAccelerateOSX;
+			sourceTree = "<group>";
+		};
+		04604A111CF260F600DD1FEB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				04604A151CF260F700DD1FEB /* libFFTAccelerateOSX.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		042600601CF259F400D4CE95 /* FFTAccelerateOSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 042600681CF259F400D4CE95 /* Build configuration list for PBXNativeTarget "FFTAccelerateOSX" */;
+			buildPhases = (
+				0426005D1CF259F400D4CE95 /* Sources */,
+				0426005E1CF259F400D4CE95 /* Frameworks */,
+				0426005F1CF259F400D4CE95 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				04604A1D1CF2617E00DD1FEB /* PBXTargetDependency */,
+			);
+			name = FFTAccelerateOSX;
+			productName = FFTAccelerateOSX;
+			productReference = 042600611CF259F400D4CE95 /* FFTAccelerateOSX */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		042600591CF259F400D4CE95 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = "Jack Jansen";
+				TargetAttributes = {
+					042600601CF259F400D4CE95 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 0426005C1CF259F400D4CE95 /* Build configuration list for PBXProject "FFTAccelerateOSX" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 042600581CF259F400D4CE95;
+			productRefGroup = 042600621CF259F400D4CE95 /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 04604A111CF260F600DD1FEB /* Products */;
+					ProjectRef = 04604A101CF260F600DD1FEB /* FFTAccelerateLibOSX.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				042600601CF259F400D4CE95 /* FFTAccelerateOSX */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		04604A151CF260F700DD1FEB /* libFFTAccelerateOSX.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libFFTAccelerateOSX.a;
+			remoteRef = 04604A141CF260F700DD1FEB /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0426005D1CF259F400D4CE95 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				042600651CF259F400D4CE95 /* main.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		04604A1D1CF2617E00DD1FEB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FFTAccelerateLibOSX;
+			targetProxy = 04604A1C1CF2617E00DD1FEB /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		042600661CF259F400D4CE95 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = FFTAccelerate;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		042600671CF259F400D4CE95 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = FFTAccelerate;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		042600691CF259F400D4CE95 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		0426006A1CF259F400D4CE95 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0426005C1CF259F400D4CE95 /* Build configuration list for PBXProject "FFTAccelerateOSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				042600661CF259F400D4CE95 /* Debug */,
+				042600671CF259F400D4CE95 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		042600681CF259F400D4CE95 /* Build configuration list for PBXNativeTarget "FFTAccelerateOSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				042600691CF259F400D4CE95 /* Debug */,
+				0426006A1CF259F400D4CE95 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 042600591CF259F400D4CE95 /* Project object */;
+}

--- a/FFTAccelerateOSX.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/FFTAccelerateOSX.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:FFTAccelerateOSX.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/FFTAccelerateOSX/main.cpp
+++ b/FFTAccelerateOSX/main.cpp
@@ -47,6 +47,7 @@ int main(int argc, const char * argv[]) {
     for (int i=0; i<numSamples; i++) {
         std::cout << "index: " << i << " amplitude: " << frequency[i] << "\n";
     }
+    std::cout << "Fullest bin: " << fftAccel->fullestBin(frequency, numSamples, false) << ", fullest ignoring DC: " << fftAccel->fullestBin(frequency, numSamples, true) << "\n";
     delete(fftAccel);
     return 0;
 }

--- a/FFTAccelerateOSX/main.cpp
+++ b/FFTAccelerateOSX/main.cpp
@@ -1,0 +1,52 @@
+//
+//  main.cpp
+//  FFTAccelerateOSX
+//
+//  Created by Jack Jansen on 22/05/16.
+//  Copyright © 2016 Jack Jansen. All rights reserved.
+//
+
+#include <iostream>
+#include <math.h>
+#include "FFTAccelerate.h"
+
+int main(int argc, const char * argv[]) {
+    // insert code here...
+    std::cout << "Hello, World!\n";
+    //Number of Samples for input(time domain)/output(frequency domain)
+    //Must be Power of 2: 2^x
+    int numSamples = 1024;
+    
+    //Output Array
+    float *frequency = (float *)malloc(sizeof(float)*numSamples);
+    
+    //Input Array
+    float *time = (float *)malloc(sizeof(float)*numSamples);
+    
+    //Fill Input Array with Sin Wave
+    for (int i=0; i<numSamples; i++) {
+        
+        //DC Component frequency[0] = 0.5
+        time[i] = 0.25;
+        
+        //First Harmonic (frequency[1]=1.0)
+        time[i] += cos(2*M_PI*i/(float)numSamples);
+        
+        //Second Harmonic (frequency[2]=1.0)
+        time[i] += cos(2*M_PI*2*i/numSamples);
+        
+        //Third Harmonic (frequency[3]=1.0)
+        time[i] += cos(2*M_PI*3*i/numSamples);
+    }
+    
+    
+    
+    FFTAccelerate *fftAccel = new FFTAccelerate(numSamples);
+    fftAccel->doFFTReal(time, frequency, numSamples);
+    
+    for (int i=0; i<numSamples; i++) {
+        std::cout << "index: " << i << " amplitude: " << frequency[i] << "\n";
+    }
+    delete(fftAccel);
+    return 0;
+}


### PR DESCRIPTION
In case you're interested here's a patch that does three things (if you really want them separate, or only one, let me know):
- Split the project into two: one for the library and one for the test program
- Added OSX library project and test program
- Added a method fullestBin that returns the index of the bin with the highest power (and the lowest bin in case there are multiple with the same power level)
